### PR TITLE
fix: vimgrep support filenames with spaces

### DIFF
--- a/grep-
+++ b/grep-
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Exclude binary files
 # Show line numbers
 # Search recursively and follow symbolic links

--- a/vimfind-
+++ b/vimfind-
@@ -1,1 +1,2 @@
-vim $(find -name $@)
+#!/bin/bash
+find . -name "$@" -print0 | xargs -0 vim

--- a/vimgrep-
+++ b/vimgrep-
@@ -1,3 +1,2 @@
 #!/bin/bash
-grep- $@ -l
 grep- $@ -lZ | xargs -0 vim

--- a/vimgrep-
+++ b/vimgrep-
@@ -1,1 +1,3 @@
-vim $(grep- $@ -l)
+#!/bin/bash
+grep- $@ -l
+grep- $@ -lZ | xargs -0 vim


### PR DESCRIPTION
fixes invisibleroads/scripts#1
